### PR TITLE
Fix default color

### DIFF
--- a/release/make_nutanix_manifest.sh
+++ b/release/make_nutanix_manifest.sh
@@ -4,7 +4,7 @@ set -e
 
 ROOT=$(dirname $0)
 
-export DOCKER_IMAGE_NAME=deepomatic/nutanix-runtime:master-19
+export DOCKER_IMAGE_NAME=deepomatic/nutanix-runtime:master-22
 export DEPLOYMENT_NAME=deepomatic-app
 export DEEPOMATIC_RUN_VERSION=0.1.0
 export DEEPOMATIC_SITE_ID=${NUTANIX_RUNTIME_SITE_ID}

--- a/runtime/main.py
+++ b/runtime/main.py
@@ -45,16 +45,18 @@ class Config(object):
         Convert environment variable FONT_COLOR from RRGGBB or RGB in hexadecimal format
         to a tuple (R, G, B).
         """
-        color = os.getenv('FONT_COLOR', 'FFFFFF')
-        try:
-            if len(color) == 6:
-                return tuple([int(c, 16) for c in textwrap.wrap(color, 2)])
-            elif len(color) == 3:
-                return tuple([int(c, 16) * 17 for c in color])
-        except ValueError:
-            pass
-        logger.error("Error parsing font color, defaulting to light blue")
-        return (109, 175, 255)
+        color = os.getenv('FONT_COLOR', None)
+        if color is not None:
+            try:
+                if len(color) == 6:
+                    return tuple([int(c, 16) for c in textwrap.wrap(color, 2)])
+                elif len(color) == 3:
+                    return tuple([int(c, 16) * 17 for c in color])
+            except ValueError:
+                pass
+            logger.error("Error parsing font color, defaulting to light blue")
+
+        return (34, 165, 247)
 
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
When `FONT_COLOR` was not specified, the drawing color was set to white. We set it to light blue.